### PR TITLE
[add]カテゴリ管理APIの追加・構成整理・命名規則ガイドラインの導入

### DIFF
--- a/front/docs/api-hooks-naming-guidelines.md
+++ b/front/docs/api-hooks-naming-guidelines.md
@@ -1,0 +1,105 @@
+## 関数命名規則ガイドライン（API / Hooks / UI）
+
+本ドキュメントでは、Next.js プロジェクトにおける関数命名の統一ルールについて記載します。特に以下の3層における命名に焦点を当て、責務の明確化と保守性の向上を目的とします。
+
+---
+
+### 🔁 命名対象の3層
+
+| 層                      | 例                  | 主な責務                                            |
+| ----------------------- | ------------------- | --------------------------------------------------- |
+| UI層（フォームなど）    | `handleAddCategory` | UIイベントのトリガーとなる関数（クリックや送信）    |
+| Hooks層（ユースケース） | `addCategory`       | ビジネスロジックの中心。API呼び出しや状態更新を担当 |
+| API呼び出し層           | `postCategory`      | 外部／内部APIへの通信を行う責務（HTTP）             |
+
+---
+
+### 🎨 UI層：イベントハンドラ関数
+
+- **プレフィックスに `handle` を使用**
+- 主に JSX のイベント属性（例: `onClick`, `onSubmit`）にバインドされる関数
+- UI操作の「起点」であり、副作用の発火役
+
+#### ✅ 命名例
+
+```ts
+const handleAddCategory = () => { ... }
+const handleSubmitForm = () => { ... }
+```
+
+---
+
+### ⚙️ Hooks層：ユースケース関数
+
+- **目的ベース（何をしたいか）で命名**
+- 状態更新＋API呼び出しなど、複合的な責務を担う
+- `useXXX` の中で定義され、UIから呼び出される想定
+- UI層やAPI層と **プレフィックスで差別化しない**（文脈で明確に）
+
+#### ✅ 命名例
+
+```ts
+const addCategory = async (data: CategoryInput) => { ... }
+const updateUserProfile = async () => { ... }
+```
+
+#### ❌ NG例
+
+```ts
+const handleAddCategory = () => {} // UI層と混同されやすい
+const fetchAndUpdateCategories = () => {} // 責務が広すぎる
+```
+
+#### 💡 補足：hooks内での `handle` 命名について
+
+- 状態更新などの **UIイベントハンドラを hooks にまとめるケース**では、`handle` プレフィックスを使っても構いません。
+- これは UI 層の複雑さを減らす目的で、hooks 側で `onChange`, `onClick` ハンドラなどを定義する設計です。
+
+```ts
+// useSignUp.ts の例
+const handleSetEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
+  setEmail(event.target.value)
+}
+const handleClickLogin = () => {
+  router.push('/login')
+}
+```
+
+- このような場合も、責務が「UI操作に密接」であることを意識し、`handle` のプレフィックスを維持してください。
+
+---
+
+### 🌐 API層：通信関数
+
+- **HTTPメソッドをプレフィックスに使う（`fetch`, `post`, `put`, `delete` など）**
+- Axios や Fetch を使って HTTP 通信を行う関数
+- データ取得／送信／更新などに特化
+
+#### ✅ 命名例
+
+```ts
+const fetchCategories = async () => { ... }
+const postCategory = async (data: CategoryInput) => { ... }
+const deleteCategory = async (id: number) => { ... }
+```
+
+#### ❌ NG例
+
+```ts
+const apiAddCategory = () => {} // プレフィックスが曖昧
+const createCategory = () => {} // HTTP動詞との対応が不明確
+```
+
+---
+
+### 📌 命名のポイントまとめ
+
+| 層    | プレフィックス例                                            | 命名意図                                 |
+| ----- | ----------------------------------------------------------- | ---------------------------------------- |
+| UI    | `handle`                                                    | UIイベントのトリガーとして明確にする     |
+| Hooks | （なし）目的ベース、または `handle`（UI操作を委譲する場合） | ドメイン操作またはUI操作補助を担う       |
+| API   | `fetch` / `post` など                                       | HTTP操作を明示することで責務を明確にする |
+
+---
+
+この命名規則をプロジェクト内で統一することで、可読性・責任の分離・拡張性が向上し、チーム開発の効率化に繋がります。

--- a/front/src/app/api/mock/categories/child/route.ts
+++ b/front/src/app/api/mock/categories/child/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Response } from '@/types/api'
+import { Category, SubCategory } from '@/types/models/category'
+import { TransactionType } from '@/types/models/transaction'
+import { incomeCategories } from '@/mocks/categories/incomeCategories'
+import { expenseCategories } from '@/mocks/categories/expenseCategories'
+
+// カテゴリーごとのサブカテゴリーのカウントを管理
+const lastIdMap = {
+  expenses: expenseCategories.map((category) => {
+    return {
+      id: category.id,
+      count: category.subCategory?.length,
+    }
+  }),
+  incomes: incomeCategories.map((category) => {
+    return {
+      id: category.id,
+      count: category.subCategory?.length,
+    }
+  }),
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json()
+  const transactionType = body.transactionType as TransactionType
+  const categoryName = body.categoryName as string
+  const parentCategoryId = body.parentCategoryId as number
+
+  if (!transactionType || !categoryName || !parentCategoryId) {
+    const result: Response<Category | null> = {
+      code: 400,
+      data: null,
+      message: [
+        'Transaction type and category name and parent category id are required.',
+      ],
+    }
+    return NextResponse.json(result)
+  }
+
+  // 次のIDを生成
+  const nextId =
+    lastIdMap[transactionType].find((v) => v.id === parentCategoryId)?.count + 1
+  // マッピング用のカウントを更新
+  lastIdMap[transactionType].map((v) => {
+    if (v.id === parentCategoryId) {
+      v.count = nextId
+    }
+    return v
+  })
+
+  const result: Response<SubCategory> = {
+    code: 200,
+    data: {
+      id: nextId,
+      name: categoryName,
+    },
+  }
+  return NextResponse.json(result)
+}

--- a/front/src/app/api/mock/categories/parent/route.ts
+++ b/front/src/app/api/mock/categories/parent/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Response } from '@/types/api'
+import { Category } from '@/types/models/category'
+import { TransactionType } from '@/types/models/transaction'
+import { incomeCategories } from '@/mocks/categories/incomeCategories'
+import { expenseCategories } from '@/mocks/categories/expenseCategories'
+
+// 既存のカテゴリから最後のIDを取得
+const lastIdMap = {
+  expenses: expenseCategories[expenseCategories.length - 1].id,
+  incomes: incomeCategories[incomeCategories.length - 1].id,
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json()
+  debugger
+  const transactionType = body.transactionType as TransactionType
+  const categoryName = body.categoryName as string
+
+  if (!transactionType || !categoryName) {
+    const result: Response<Category | null> = {
+      code: 400,
+      data: null,
+      message: ['Transaction type and category name are required.'],
+    }
+    return NextResponse.json(result)
+  }
+
+  // 次のIDを生成
+  const nextId = lastIdMap[transactionType] + 1
+  lastIdMap[transactionType] = nextId
+
+  const result: Response<Category> = {
+    code: 200,
+    data: {
+      id: nextId,
+      name: categoryName,
+      subCategory: [],
+    },
+  }
+  return NextResponse.json(result)
+}

--- a/front/src/app/api/mock/categories/route.ts
+++ b/front/src/app/api/mock/categories/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { expenseCategories } from '@/mocks/categories/expenseCategories'
+import { incomeCategories } from '@/mocks/categories/incomeCategories'
+import { Response } from '@/types/api'
+import { TransactionType } from '@/types/models/transaction'
+import { Category } from '@/types/models/category'
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const transactionType = searchParams.get('transactionType') as TransactionType
+
+  if (!transactionType) {
+    const result: Response = {
+      code: 400,
+      message: ['Transaction type is required.'],
+    }
+    return NextResponse.json(result)
+  }
+
+  const data =
+    transactionType === 'expenses' ? expenseCategories : incomeCategories
+
+  const result: Response<Category[]> = {
+    code: 200,
+    data: data,
+  }
+  return NextResponse.json(result)
+}

--- a/front/src/components/SidePanel.tsx
+++ b/front/src/components/SidePanel.tsx
@@ -6,7 +6,7 @@ import {
   TagIcon,
   UserCircleIcon,
 } from '@heroicons/react/24/outline'
-import { paths } from '@/config/paths'
+import { routes } from '@/config/routes'
 
 const SidePanel = () => {
   type Menu = {
@@ -17,22 +17,22 @@ const SidePanel = () => {
   const menuList: Menu[] = [
     {
       name: 'ダッシュボード',
-      url: paths.app.home,
+      url: routes.app.home,
       icon: <ChartBarIcon className="h-5 w-5" />,
     },
     {
       name: '収入',
-      url: paths.app.incomes,
+      url: routes.app.incomes,
       icon: <CurrencyYenIcon className="h-5 w-5" />,
     },
     {
       name: '支出',
-      url: paths.app.expenses,
+      url: routes.app.expenses,
       icon: <ShoppingBagIcon className="h-5 w-5" />,
     },
     {
       name: 'カテゴリ',
-      url: paths.app.categories,
+      url: routes.app.categories,
       icon: <TagIcon className="h-5 w-5" />,
     },
   ]
@@ -55,7 +55,7 @@ const SidePanel = () => {
       </nav>
       <div className="px-4 mt-10">
         <button className="bg-red-500 text-white hover:bg-red-300 rounded-md px-4 py-2 cursor-pointer">
-          <Link className="flex items-center py-2" href={paths.auth.login}>
+          <Link className="flex items-center py-2" href={routes.auth.login}>
             ログアウト
           </Link>
         </button>

--- a/front/src/config/api.ts
+++ b/front/src/config/api.ts
@@ -1,0 +1,29 @@
+/**
+ * API設定
+ */
+
+// 環境変数からAPIの設定を取得
+const isMockMode = process.env.NEXT_PUBLIC_API_MOCK_MODE === 'true'
+const baseURL = isMockMode
+  ? process.env.NEXT_PUBLIC_API_MOCK_URL
+  : process.env.NEXT_PUBLIC_API_PRODUCTION_URL
+
+export const api = {
+  baseURL,
+  endpoints: {
+    auth: {
+      register: '/auth/register',
+      login: '/auth/login',
+    },
+    categories: {
+      // list取得用
+      getList: '/categories',
+      // 追加用
+      create: '/categories',
+      // 更新用
+      update: '/categories/:id',
+      // 削除用
+      delete: '/categories/:id',
+    },
+  },
+}

--- a/front/src/config/api.ts
+++ b/front/src/config/api.ts
@@ -19,9 +19,10 @@ export const api = {
       // list取得用
       getList: '/categories',
       // 追加用
-      create: '/categories',
+      postParent: '/categories/parent',
+      postChild: '/categories/child',
       // 更新用
-      update: '/categories/:id',
+      put: '/categories/:id',
       // 削除用
       delete: '/categories/:id',
     },

--- a/front/src/config/routes.ts
+++ b/front/src/config/routes.ts
@@ -1,13 +1,7 @@
 /**
- * パスの定義
+ * アプリケーションのルーティングパス
  */
-export const paths = {
-  api: {
-    auth: {
-      register: '/auth/register',
-      login: '/auth/login',
-    },
-  },
+export const routes = {
   app: {
     home: '/app',
     categories: '/app/categories',

--- a/front/src/features/app/apis/categories.ts
+++ b/front/src/features/app/apis/categories.ts
@@ -2,7 +2,7 @@ import globalAxios, { isAxiosError } from '@/libs/api-client'
 import { Response, ApiError } from '@/types/api'
 import { api } from '@/config/api'
 import { TransactionType } from '@/types/models/transaction'
-import { Category } from '@/types/models/category'
+import { Category, SubCategory } from '@/types/models/category'
 import { AxiosResponse } from 'axios'
 
 export const fetchCategories = async (
@@ -47,6 +47,39 @@ export const postParentCategory = async (
       await globalAxios.post(api.endpoints.categories.postParent, {
         transactionType,
         categoryName,
+      })
+    return {
+      code: 200,
+      data: data.data,
+    }
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const axiosError = error as ApiError
+      return {
+        code: axiosError.response?.status ?? 500,
+        data: null,
+        message: axiosError.response?.data?.error?.message,
+      }
+    }
+    return {
+      code: 500,
+      data: null,
+      message: ['An error occurred while login.'],
+    }
+  }
+}
+
+export const postChildCategory = async (
+  transactionType: TransactionType,
+  categoryName: string,
+  parentCategoryId: number,
+): Promise<Response<SubCategory | null>> => {
+  try {
+    const { data }: AxiosResponse<Response<SubCategory | null>> =
+      await globalAxios.post(api.endpoints.categories.postChild, {
+        transactionType,
+        categoryName,
+        parentCategoryId,
       })
     return {
       code: 200,

--- a/front/src/features/app/apis/categories.ts
+++ b/front/src/features/app/apis/categories.ts
@@ -1,0 +1,70 @@
+import globalAxios, { isAxiosError } from '@/libs/api-client'
+import { Response, ApiError } from '@/types/api'
+import { api } from '@/config/api'
+import { TransactionType } from '@/types/models/transaction'
+import { Category } from '@/types/models/category'
+import { AxiosResponse } from 'axios'
+
+export const fetchCategories = async (
+  transactionType: TransactionType,
+): Promise<Response<Category[]>> => {
+  try {
+    const { data }: AxiosResponse<Response<Category[]>> = await globalAxios.get(
+      api.endpoints.categories.getList,
+      {
+        params: {
+          transactionType,
+        },
+      },
+    )
+    return {
+      code: 200,
+      data: data.data,
+    }
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const axiosError = error as ApiError
+      return {
+        code: axiosError.response?.status ?? 500,
+        data: [],
+        message: axiosError.response?.data.error.message,
+      }
+    }
+    return {
+      code: 500,
+      data: [],
+      message: ['An error occurred while login.'],
+    }
+  }
+}
+
+export const postParentCategory = async (
+  transactionType: TransactionType,
+  categoryName: string,
+): Promise<Response<Category | null>> => {
+  try {
+    const { data }: AxiosResponse<Response<Category | null>> =
+      await globalAxios.post(api.endpoints.categories.postParent, {
+        transactionType,
+        categoryName,
+      })
+    return {
+      code: 200,
+      data: data.data,
+    }
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const axiosError = error as ApiError
+      return {
+        code: axiosError.response?.status ?? 500,
+        data: null,
+        message: axiosError.response?.data?.error?.message,
+      }
+    }
+    return {
+      code: 500,
+      data: null,
+      message: ['An error occurred while login.'],
+    }
+  }
+}

--- a/front/src/features/app/components/categories/CategoryList.tsx
+++ b/front/src/features/app/components/categories/CategoryList.tsx
@@ -4,7 +4,7 @@ import { useCategoryContext } from '@/features/app/contexts/categories/CategoryC
 import InputForm from './InputForm'
 
 const CategoriesList = () => {
-  const { categoryList } = useCategoryContext()
+  const { categoryList, transactionType } = useCategoryContext()
   return (
     <div className="flex flex-col gap-1 px-5 pt-2 max-h-150 overflow-auto">
       {categoryList.map((category, index) => (
@@ -19,12 +19,15 @@ const CategoriesList = () => {
             </div>
           ))}
           <div className="ml-3 w-2/4">
-            <InputForm />
+            <InputForm
+              transactionType={transactionType}
+              parentCategory={category}
+            />
           </div>
         </div>
       ))}
       <div className="rounded-md pt-1 pb-5">
-        <InputForm />
+        <InputForm transactionType={transactionType} />
       </div>
     </div>
   )

--- a/front/src/features/app/components/categories/InputForm.tsx
+++ b/front/src/features/app/components/categories/InputForm.tsx
@@ -1,7 +1,39 @@
 'use client'
 import { PlusCircleIcon } from '@heroicons/react/16/solid'
+import { useState } from 'react'
+import { useCategoryContext } from '@/features/app/contexts/categories/CategoryContext'
+import { Category } from '@/types/models/category'
+import { Event } from '@/types/event'
+import { TransactionType } from '@/types/models/transaction'
 
-const InputForm: React.FC = () => {
+type InputFormProps = {
+  transactionType: TransactionType
+  parentCategory?: Category
+}
+const InputForm: React.FC<InputFormProps> = ({
+  transactionType,
+  parentCategory,
+}) => {
+  const { addParentCategory } = useCategoryContext()
+  const [category, setCategory] = useState('')
+
+  const handleAddCategory = () => {
+    if (category === '') {
+      return
+    }
+
+    if (!parentCategory) {
+      addParentCategory(transactionType, category)
+    } else {
+      // addParentCategory(transactionType, category)
+    }
+    setCategory('')
+  }
+  const handleKeyDown: Event['onKeyDown'] = (e) => {
+    if (e.key === 'Enter') {
+      handleAddCategory()
+    }
+  }
   return (
     <>
       <div className="flex gap-3 items-center text-sm">
@@ -9,11 +41,17 @@ const InputForm: React.FC = () => {
           <input
             type="text"
             placeholder="新しいカテゴリを登録"
-            className="w-full"
+            className="w-full px-2 py-1"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
         </div>
         <p>
-          <PlusCircleIcon className="h-5 w-5 cursor-pointer" />
+          <PlusCircleIcon
+            className="h-5 w-5 cursor-pointer"
+            onClick={handleAddCategory}
+          />
         </p>
       </div>
     </>

--- a/front/src/features/app/components/categories/InputForm.tsx
+++ b/front/src/features/app/components/categories/InputForm.tsx
@@ -14,7 +14,7 @@ const InputForm: React.FC<InputFormProps> = ({
   transactionType,
   parentCategory,
 }) => {
-  const { addParentCategory } = useCategoryContext()
+  const { addParentCategory, addChildCategory } = useCategoryContext()
   const [category, setCategory] = useState('')
 
   const handleAddCategory = () => {
@@ -22,10 +22,10 @@ const InputForm: React.FC<InputFormProps> = ({
       return
     }
 
-    if (!parentCategory) {
-      addParentCategory(transactionType, category)
+    if (parentCategory) {
+      addChildCategory(transactionType, category, parentCategory.id)
     } else {
-      // addParentCategory(transactionType, category)
+      addParentCategory(transactionType, category)
     }
     setCategory('')
   }

--- a/front/src/features/app/contexts/categories/CategoryContext.tsx
+++ b/front/src/features/app/contexts/categories/CategoryContext.tsx
@@ -1,20 +1,18 @@
 'use client'
 
-import React, {
-  createContext,
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import React, { createContext, ReactNode, useContext } from 'react'
 import { Category } from '@/types/models/category'
 import { TransactionType } from '@/types/models/transaction'
+import { useCategories } from '@/features/app/hooks/categories/useCategories'
 
 export type CategoryContextType = {
   transactionType: TransactionType
   categoryList: Category[]
   changeTransactionType: (transactionType: TransactionType) => void
+  addParentCategory: (
+    transactionType: TransactionType,
+    categoryName: string,
+  ) => void
 }
 
 // 明示的な型アノテーションを追加
@@ -28,35 +26,19 @@ type CategoryProviderProps = {
 export const CategoryProvider: React.FC<CategoryProviderProps> = ({
   children,
 }) => {
-  const [transactionType, setTransactionType] =
-    useState<TransactionType>('incomes')
-  const [categoryList, setCategoryList] = useState<Category[]>([] as Category[])
-
-  const changeTransactionType = useCallback(
-    (transactionType: TransactionType) => {
-      setTransactionType(transactionType)
-    },
-    [transactionType],
-  )
-
-  useEffect(() => {
-    let newCategoryList
-    switch (transactionType) {
-      case 'incomes':
-        newCategoryList = incomeCategoryList
-        break
-      case 'expenses':
-        newCategoryList = expenseCategoryList
-        break
-    }
-    setCategoryList(newCategoryList)
-  }, [transactionType])
+  const {
+    categoryList,
+    changeTransactionType,
+    addParentCategory,
+    transactionType,
+  } = useCategories()
   return (
     <CategoryContext.Provider
       value={{
         transactionType,
         categoryList,
         changeTransactionType,
+        addParentCategory,
       }}
     >
       {children}
@@ -71,194 +53,3 @@ export const useCategoryContext = () => {
   }
   return context
 }
-
-/**
- * 仮データ
- */
-const expenseCategoryList: Category[] = [
-  {
-    id: 1,
-    name: '食費',
-    subCategory: [
-      { id: 101, name: '食料品' },
-      { id: 102, name: '外食' },
-      { id: 103, name: 'カフェ' },
-      { id: 104, name: '朝食' },
-      { id: 105, name: '昼食' },
-      { id: 106, name: '夕食' },
-      { id: 107, name: '夜食' },
-      { id: 108, name: 'その他食費' },
-    ],
-  },
-  {
-    id: 2,
-    name: '日用品',
-    subCategory: [
-      { id: 201, name: '衣服' },
-      { id: 202, name: '靴' },
-      { id: 203, name: 'アクセサリー' },
-      { id: 204, name: '化粧品' },
-      { id: 205, name: '生活用品' },
-      { id: 206, name: 'その他日用品' },
-    ],
-  },
-  {
-    id: 3,
-    name: '趣味・娯楽',
-    subCategory: [
-      { id: 301, name: 'アウトドア' },
-      { id: 302, name: 'スポーツ' },
-      { id: 303, name: 'ゲーム' },
-      { id: 304, name: '映画・音楽' },
-      { id: 305, name: '本' },
-      { id: 306, name: '旅行' },
-      { id: 307, name: 'その他趣味' },
-    ],
-  },
-  {
-    id: 4,
-    name: '交通費',
-    subCategory: [
-      { id: 401, name: '電車' },
-      { id: 402, name: 'バス' },
-      { id: 403, name: 'タクシー' },
-      { id: 404, name: '飛行機' },
-      { id: 405, name: 'その他交通費' },
-    ],
-  },
-  {
-    id: 5,
-    name: '健康・医療',
-    subCategory: [
-      { id: 501, name: '医療費' },
-      { id: 502, name: '薬' },
-      { id: 503, name: '歯科' },
-      { id: 504, name: 'フィットネス' },
-      { id: 505, name: 'ボディケア' },
-      { id: 506, name: 'その他医療費' },
-    ],
-  },
-  {
-    id: 6,
-    name: '自動車',
-    subCategory: [
-      { id: 601, name: 'ガソリン' },
-      { id: 602, name: '駐車場' },
-      { id: 603, name: '車検・整備' },
-      { id: 604, name: '高速料金' },
-      { id: 605, name: 'その他自動車費' },
-    ],
-  },
-  {
-    id: 7,
-    name: '教育・教養',
-    subCategory: [
-      { id: 701, name: '書籍' },
-      { id: 702, name: '新聞・雑誌' },
-      { id: 703, name: '習い事' },
-      { id: 704, name: 'セミナー' },
-      { id: 705, name: '学費' },
-      { id: 706, name: 'その他教育費' },
-    ],
-  },
-  {
-    id: 8,
-    name: '特別な支出',
-    subCategory: [
-      { id: 801, name: '冠婚葬祭' },
-      { id: 802, name: '誕生日' },
-      { id: 803, name: '記念日' },
-      { id: 804, name: 'プレゼント' },
-      { id: 805, name: 'その他特別費' },
-    ],
-  },
-  {
-    id: 9,
-    name: '現金・カード',
-    subCategory: [
-      { id: 901, name: 'ATM引き出し' },
-      { id: 902, name: '電子マネーチャージ' },
-      { id: 903, name: 'カード引き落とし' },
-      { id: 904, name: 'その他現金・カード' },
-    ],
-  },
-  {
-    id: 10,
-    name: '通信費',
-    subCategory: [
-      { id: 1001, name: '携帯電話' },
-      { id: 1002, name: '固定電話' },
-      { id: 1003, name: 'インターネット' },
-      { id: 1004, name: '放送視聴料' },
-      { id: 1005, name: 'その他通信費' },
-    ],
-  },
-  {
-    id: 11,
-    name: '住宅',
-    subCategory: [
-      { id: 1101, name: '家賃' },
-      { id: 1102, name: '地震・火災保険' },
-      { id: 1103, name: '修繕・メンテナンス' },
-      { id: 1104, name: 'その他住宅費' },
-    ],
-  },
-  {
-    id: 12,
-    name: '水道・光熱費',
-    subCategory: [
-      { id: 1201, name: '電気代' },
-      { id: 1202, name: 'ガス代' },
-      { id: 1203, name: '水道代' },
-      { id: 1204, name: 'その他水道・光熱費' },
-    ],
-  },
-  {
-    id: 13,
-    name: '税金・保険',
-    subCategory: [
-      { id: 1301, name: '所得税' },
-      { id: 1302, name: '住民税' },
-      { id: 1303, name: '年金保険料' },
-      { id: 1304, name: '健康保険' },
-      { id: 1305, name: '生命保険' },
-      { id: 1306, name: '自動車保険' },
-      { id: 1307, name: 'その他税・保険' },
-    ],
-  },
-  {
-    id: 16,
-    name: 'その他',
-    subCategory: [
-      { id: 1601, name: '仕送り' },
-      { id: 1602, name: '寄付金' },
-      { id: 1603, name: '雑費' },
-      { id: 1604, name: 'その他' },
-    ],
-  },
-  {
-    id: 17,
-    name: '未分類',
-    subCategory: [],
-  },
-]
-const incomeCategoryList: Category[] = [
-  {
-    id: 1,
-    name: '給与',
-    subCategory: [
-      { id: 101, name: '給与' },
-      { id: 102, name: '賞与' },
-    ],
-  },
-  {
-    id: 2,
-    name: 'その他',
-    subCategory: [
-      { id: 201, name: '配当金' },
-      { id: 202, name: '不動産収入' },
-      { id: 203, name: '臨時収入' },
-      { id: 204, name: 'お小遣い' },
-    ],
-  },
-]

--- a/front/src/features/app/contexts/categories/CategoryContext.tsx
+++ b/front/src/features/app/contexts/categories/CategoryContext.tsx
@@ -13,6 +13,11 @@ export type CategoryContextType = {
     transactionType: TransactionType,
     categoryName: string,
   ) => void
+  addChildCategory: (
+    transactionType: TransactionType,
+    categoryName: string,
+    parentCategoryId: number,
+  ) => void
 }
 
 // 明示的な型アノテーションを追加
@@ -30,6 +35,7 @@ export const CategoryProvider: React.FC<CategoryProviderProps> = ({
     categoryList,
     changeTransactionType,
     addParentCategory,
+    addChildCategory,
     transactionType,
   } = useCategories()
   return (
@@ -39,6 +45,7 @@ export const CategoryProvider: React.FC<CategoryProviderProps> = ({
         categoryList,
         changeTransactionType,
         addParentCategory,
+        addChildCategory,
       }}
     >
       {children}

--- a/front/src/features/app/hooks/categories/useCategories.ts
+++ b/front/src/features/app/hooks/categories/useCategories.ts
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { TransactionType } from '@/types/models/transaction'
+import { Category } from '@/types/models/category'
+import {
+  fetchCategories,
+  postParentCategory,
+} from '@/features/app/apis/categories'
+
+export const useCategories = () => {
+  const [transactionType, setTransactionType] =
+    useState<TransactionType>('incomes')
+  const [categories, setCategories] = useState<{
+    incomes: Category[]
+    expenses: Category[]
+  }>({
+    incomes: [],
+    expenses: [],
+  })
+
+  const changeTransactionType = useCallback(
+    (newTransactionType: TransactionType) => {
+      setTransactionType(newTransactionType)
+    },
+    [],
+  )
+
+  // 両方のトランザクションタイプのカテゴリを取得
+  const fetchAllCategories = useCallback(async () => {
+    try {
+      const [incomesResponse, expensesResponse] = await Promise.all([
+        fetchCategories('incomes'),
+        fetchCategories('expenses'),
+      ])
+
+      if (incomesResponse.code !== 200 || expensesResponse.code !== 200) {
+        console.error('Failed to fetch categories')
+        return
+      }
+
+      setCategories({
+        incomes: incomesResponse.data ?? [],
+        expenses: expensesResponse.data ?? [],
+      })
+    } catch (error) {
+      console.error('Error fetching categories:', error)
+    }
+  }, [])
+
+  // カテゴリを追加
+  const addParentCategory = useCallback(
+    async (transactionType: TransactionType, categoryName: string) => {
+      const response = await postParentCategory(transactionType, categoryName)
+      if (response.code !== 200 || response?.data === null) {
+        console.error(response.message)
+        return
+      }
+
+      const categoryData = response.data as Category
+      setCategories((prev) => ({
+        ...prev,
+        [transactionType]: [
+          ...prev[transactionType],
+          {
+            id: categoryData.id,
+            name: categoryName,
+          },
+        ],
+      }))
+    },
+    [],
+  )
+
+  // 初期表示時に両方のカテゴリを取得
+  useEffect(() => {
+    fetchAllCategories()
+  }, [fetchAllCategories])
+
+  return {
+    categoryList: categories[transactionType],
+    changeTransactionType,
+    addParentCategory,
+    transactionType,
+  }
+}

--- a/front/src/features/auth/apis/login.ts
+++ b/front/src/features/auth/apis/login.ts
@@ -1,10 +1,10 @@
 import globalAxios, { isAxiosError } from '@/libs/api-client'
 import { Response, ApiError } from '@/types/api'
-import { paths } from '@/config/paths'
+import { api } from '@/config/api'
 
 export const login = async (email: string, password: string) => {
   try {
-    await globalAxios.post(paths.api.auth.login, {
+    await globalAxios.post(api.endpoints.auth.login, {
       email,
       password,
     })

--- a/front/src/features/auth/apis/register-user.ts
+++ b/front/src/features/auth/apis/register-user.ts
@@ -1,10 +1,10 @@
 import globalAxios, { isAxiosError } from '@/libs/api-client'
 import { Response, ApiError } from '@/types/api'
-import { paths } from '@/config/paths'
+import { api } from '@/config/api'
 
 export const signUp = async (email: string, name: string, password: string) => {
   try {
-    await globalAxios.post(paths.api.auth.register, {
+    await globalAxios.post(api.endpoints.auth.register, {
       email,
       name,
       password,

--- a/front/src/features/auth/components/LoginForm.tsx
+++ b/front/src/features/auth/components/LoginForm.tsx
@@ -1,10 +1,5 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useState } from 'react'
-import { Event } from '@/types/event'
-import { redirect } from 'next/navigation'
-import { paths } from '@/config/paths'
 import { useLoginContext } from '../contexts/LoginContext'
 
 const LoginForm = () => {

--- a/front/src/features/auth/hooks/useLogin.tsx
+++ b/front/src/features/auth/hooks/useLogin.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { Event } from '@/types/event'
 import { useRouter, redirect } from 'next/navigation'
 import { login } from '../apis/login'
-import { paths } from '@/config/paths'
+import { routes } from '@/config/routes'
 
 export const useLogin = () => {
   // state
@@ -21,7 +21,7 @@ export const useLogin = () => {
     setPassword(event.target.value)
   }
   const handleClickSignUp = () => {
-    router.push(paths.auth.signup)
+    router.push(routes.auth.signup)
   }
 
   /**
@@ -45,7 +45,7 @@ export const useLogin = () => {
     }
 
     // 認証OK
-    redirect(paths.app.home)
+    redirect(routes.app.home)
   }
 
   // 何かしら入力されたらエラーメッセージを削除

--- a/front/src/features/auth/hooks/useSignUp.tsx
+++ b/front/src/features/auth/hooks/useSignUp.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { Event } from '@/types/event'
 import { useRouter, redirect } from 'next/navigation'
 import { signUp } from '../apis/register-user'
-import { paths } from '@/config/paths'
+import { routes } from '@/config/routes'
 
 export const useSignUp = () => {
   // state
@@ -28,7 +28,7 @@ export const useSignUp = () => {
     setPasswordConfirmation(event.target.value)
   }
   const handleClickLogin = () => {
-    router.push(paths.auth.login)
+    router.push(routes.auth.login)
   }
 
   /**
@@ -57,7 +57,7 @@ export const useSignUp = () => {
     }
 
     // 認証OK
-    redirect(paths.app.home)
+    redirect(routes.app.home)
   }
 
   // 何かしら入力されたらエラーメッセージを削除

--- a/front/src/libs/api-client.ts
+++ b/front/src/libs/api-client.ts
@@ -1,9 +1,9 @@
 import axios, { AxiosError } from 'axios'
-import { BACK_API_ENDPOINT } from '@/config/server'
+import { api } from '@/config/api'
 
 // axiosのインスタンスを作成
 const globalAxios = axios.create({
-  baseURL: BACK_API_ENDPOINT,
+  baseURL: api.baseURL,
   headers: {
     'Content-type': 'application/json',
   },

--- a/front/src/mocks/categories/expenseCategories.ts
+++ b/front/src/mocks/categories/expenseCategories.ts
@@ -1,0 +1,169 @@
+import { Category } from '@/types/models/category'
+
+export const expenseCategories: Category[] = [
+  {
+    id: 1,
+    name: '食費',
+    subCategory: [
+      { id: 101, name: '食料品' },
+      { id: 102, name: '外食' },
+      { id: 103, name: 'カフェ' },
+      { id: 104, name: '朝食' },
+      { id: 105, name: '昼食' },
+      { id: 106, name: '夕食' },
+      { id: 107, name: '夜食' },
+      { id: 108, name: 'その他食費' },
+    ],
+  },
+  {
+    id: 2,
+    name: '日用品',
+    subCategory: [
+      { id: 201, name: '衣服' },
+      { id: 202, name: '靴' },
+      { id: 203, name: 'アクセサリー' },
+      { id: 204, name: '化粧品' },
+      { id: 205, name: '生活用品' },
+      { id: 206, name: 'その他日用品' },
+    ],
+  },
+  {
+    id: 3,
+    name: '趣味・娯楽',
+    subCategory: [
+      { id: 301, name: 'アウトドア' },
+      { id: 302, name: 'スポーツ' },
+      { id: 303, name: 'ゲーム' },
+      { id: 304, name: '映画・音楽' },
+      { id: 305, name: '本' },
+      { id: 306, name: '旅行' },
+      { id: 307, name: 'その他趣味' },
+    ],
+  },
+  {
+    id: 4,
+    name: '交通費',
+    subCategory: [
+      { id: 401, name: '電車' },
+      { id: 402, name: 'バス' },
+      { id: 403, name: 'タクシー' },
+      { id: 404, name: '飛行機' },
+      { id: 405, name: 'その他交通費' },
+    ],
+  },
+  {
+    id: 5,
+    name: '健康・医療',
+    subCategory: [
+      { id: 501, name: '医療費' },
+      { id: 502, name: '薬' },
+      { id: 503, name: '歯科' },
+      { id: 504, name: 'フィットネス' },
+      { id: 505, name: 'ボディケア' },
+      { id: 506, name: 'その他医療費' },
+    ],
+  },
+  {
+    id: 6,
+    name: '自動車',
+    subCategory: [
+      { id: 601, name: 'ガソリン' },
+      { id: 602, name: '駐車場' },
+      { id: 603, name: '車検・整備' },
+      { id: 604, name: '高速料金' },
+      { id: 605, name: 'その他自動車費' },
+    ],
+  },
+  {
+    id: 7,
+    name: '教育・教養',
+    subCategory: [
+      { id: 701, name: '書籍' },
+      { id: 702, name: '新聞・雑誌' },
+      { id: 703, name: '習い事' },
+      { id: 704, name: 'セミナー' },
+      { id: 705, name: '学費' },
+      { id: 706, name: 'その他教育費' },
+    ],
+  },
+  {
+    id: 8,
+    name: '特別な支出',
+    subCategory: [
+      { id: 801, name: '冠婚葬祭' },
+      { id: 802, name: '誕生日' },
+      { id: 803, name: '記念日' },
+      { id: 804, name: 'プレゼント' },
+      { id: 805, name: 'その他特別費' },
+    ],
+  },
+  {
+    id: 9,
+    name: '現金・カード',
+    subCategory: [
+      { id: 901, name: 'ATM引き出し' },
+      { id: 902, name: '電子マネーチャージ' },
+      { id: 903, name: 'カード引き落とし' },
+      { id: 904, name: 'その他現金・カード' },
+    ],
+  },
+  {
+    id: 10,
+    name: '通信費',
+    subCategory: [
+      { id: 1001, name: '携帯電話' },
+      { id: 1002, name: '固定電話' },
+      { id: 1003, name: 'インターネット' },
+      { id: 1004, name: '放送視聴料' },
+      { id: 1005, name: 'その他通信費' },
+    ],
+  },
+  {
+    id: 11,
+    name: '住宅',
+    subCategory: [
+      { id: 1101, name: '家賃' },
+      { id: 1102, name: '地震・火災保険' },
+      { id: 1103, name: '修繕・メンテナンス' },
+      { id: 1104, name: 'その他住宅費' },
+    ],
+  },
+  {
+    id: 12,
+    name: '水道・光熱費',
+    subCategory: [
+      { id: 1201, name: '電気代' },
+      { id: 1202, name: 'ガス代' },
+      { id: 1203, name: '水道代' },
+      { id: 1204, name: 'その他水道・光熱費' },
+    ],
+  },
+  {
+    id: 13,
+    name: '税金・保険',
+    subCategory: [
+      { id: 1301, name: '所得税' },
+      { id: 1302, name: '住民税' },
+      { id: 1303, name: '年金保険料' },
+      { id: 1304, name: '健康保険' },
+      { id: 1305, name: '生命保険' },
+      { id: 1306, name: '自動車保険' },
+      { id: 1307, name: 'その他税・保険' },
+    ],
+  },
+  {
+    id: 16,
+    name: 'その他',
+    subCategory: [
+      { id: 1601, name: '仕送り' },
+      { id: 1602, name: '寄付金' },
+      { id: 1603, name: '雑費' },
+      { id: 1604, name: 'その他' },
+    ],
+  },
+  {
+    id: 17,
+    name: '未分類',
+    subCategory: [],
+  },
+]

--- a/front/src/mocks/categories/incomeCategories.ts
+++ b/front/src/mocks/categories/incomeCategories.ts
@@ -1,0 +1,22 @@
+import { Category } from '@/types/models/category'
+
+export const incomeCategories: Category[] = [
+  {
+    id: 1,
+    name: '給与',
+    subCategory: [
+      { id: 101, name: '給与' },
+      { id: 102, name: '賞与' },
+    ],
+  },
+  {
+    id: 2,
+    name: 'その他',
+    subCategory: [
+      { id: 201, name: '配当金' },
+      { id: 202, name: '不動産収入' },
+      { id: 203, name: '臨時収入' },
+      { id: 204, name: 'お小遣い' },
+    ],
+  },
+]

--- a/front/src/types/event.ts
+++ b/front/src/types/event.ts
@@ -1,7 +1,8 @@
-import { ChangeEvent, FormEvent, MouseEvent } from 'react'
+import { ChangeEvent, FormEvent, KeyboardEvent, MouseEvent } from 'react'
 
 export type Event = {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   onChangeInput: (event: ChangeEvent<HTMLInputElement>) => void
   onClick: (event: MouseEvent<HTMLInputElement>) => void
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void
 }


### PR DESCRIPTION
copilotで説明文を生成してみた
良さげ!!!

----

このプルリクエストでは、以下の3点を中心に**プロジェクト全体にわたる大幅な更新**を行っています：

- 🆕 新しいAPIエンドポイントの追加  
- 🛠️ カテゴリ管理ロジックの更新  
- 🧹 命名規則や設定ファイルの整理

---

### 🔌 新しいAPIエンドポイントとロジック

[categories/child/route.ts](https://github.com/kokiwaku/Kakeibo/pull/15)
サブカテゴリ作成用のPOSTエンドポイントを追加。IDの管理ロジックも含まれています。

[categories/parent/route.ts](https://github.com/kokiwaku/Kakeibo/pull/15)
親カテゴリ作成用のPOSTエンドポイントを追加。同様にID管理ロジックあり。

[categories/route.ts](https://github.com/kokiwaku/Kakeibo/pull/15)
取引種別に応じてカテゴリを取得するGETエンドポイントを追加。

---

### ⚙️ 設定・ルーティングの更新

[api.ts](https://github.com/kokiwaku/Kakeibo/pull/15)
APIの設定ファイルを新規作成（Mock/本番URL両方対応）。

[routes.ts](https://github.com/kokiwaku/Kakeibo/pull/15)
paths.tsをroutes.tsにリネームし、ルーティングパスを整理。

---

### 🧩 コンポーネント・Contextの更新

[CategoryList.tsx](https://github.com/kokiwaku/Kakeibo/pull/15)
transactionTypeを追加し、InputFormに渡すように変更。

[InputForm.tsx](https://github.com/kokiwaku/Kakeibo/pull/15)
transactionTypeやparentCategoryに応じて、親/子カテゴリの追加処理を実装。

[CategoryContext.tsx](https://github.com/kokiwaku/Kakeibo/pull/15)
新たに作成したuseCategoriesフックを使用するようにリファクタリング。

---

### 🧾 命名規則のドキュメント追加

[api-hooks-naming-guidelines.md](https://github.com/kokiwaku/Kakeibo/pull/15)
Next.jsプロジェクトにおけるUI層・Hooks層・API層での命名ガイドラインを追加。

---

### 💡まとめ

今回の変更は、**カテゴリ管理機能の拡張**に加えて、**命名規則や設定ファイルの整理**を通じて、プロジェクトの構造と保守性の向上を目的としています ✅