### PR TITLE
カテゴリデータ取得時のローディング状態を実装しUXを向上

### DIFF
--- a/front/src/features/app/components/categories/CategoriesContent.tsx
+++ b/front/src/features/app/components/categories/CategoriesContent.tsx
@@ -1,13 +1,23 @@
 'use client'
 
+import { useCategoryContext } from '../../contexts/categories/CategoryContext'
 import CategoriesList from './CategoryList'
 import TransactionToggleTab from './TransactionToggleTab'
 
 const CategoriesContent = () => {
+  const { loading } = useCategoryContext()
   return (
     <div className="flex flex-col gap-3 bg-white rounded-md">
-      <TransactionToggleTab />
-      <CategoriesList />
+      {loading ? (
+        <div className="flex justify-center items-center h-full">
+          <div className="animate-spin rounded-full h-50 w-50 border-t-2 border-b-2 border-gray-900 m-5"></div>
+        </div>
+      ) : (
+        <>
+          <TransactionToggleTab />
+          <CategoriesList />
+        </>
+      )}
     </div>
   )
 }

--- a/front/src/features/app/contexts/categories/CategoryContext.tsx
+++ b/front/src/features/app/contexts/categories/CategoryContext.tsx
@@ -18,6 +18,7 @@ export type CategoryContextType = {
     categoryName: string,
     parentCategoryId: number,
   ) => void
+  loading: boolean
 }
 
 // 明示的な型アノテーションを追加
@@ -37,6 +38,7 @@ export const CategoryProvider: React.FC<CategoryProviderProps> = ({
     addParentCategory,
     addChildCategory,
     transactionType,
+    loading,
   } = useCategories()
   return (
     <CategoryContext.Provider
@@ -46,6 +48,7 @@ export const CategoryProvider: React.FC<CategoryProviderProps> = ({
         changeTransactionType,
         addParentCategory,
         addChildCategory,
+        loading,
       }}
     >
       {children}

--- a/front/src/features/app/hooks/categories/useCategories.ts
+++ b/front/src/features/app/hooks/categories/useCategories.ts
@@ -17,6 +17,7 @@ export const useCategories = () => {
     incomes: [],
     expenses: [],
   })
+  const [loading, setLoading] = useState(true)
 
   const changeTransactionType = useCallback(
     (newTransactionType: TransactionType) => {
@@ -111,6 +112,7 @@ export const useCategories = () => {
   // 初期表示時に両方のカテゴリを取得
   useEffect(() => {
     fetchAllCategories()
+    setLoading(false)
   }, [fetchAllCategories])
 
   return {
@@ -119,5 +121,6 @@ export const useCategories = () => {
     addParentCategory,
     addChildCategory,
     transactionType,
+    loading,
   }
 }


### PR DESCRIPTION
This pull request introduces a loading state to the categories feature in the application. The changes include updating the context, hooks, and components to handle and display the loading state.

### Loading State Implementation:

* [`front/src/features/app/components/categories/CategoriesContent.tsx`](diffhunk://#diff-6f17fbec229c01c3396eb1d1a3a04d845562d628fe20bba1b9721fe3823ea39fR3-R20): Added a loading spinner to the `CategoriesContent` component to display while categories are being fetched.
* [`front/src/features/app/contexts/categories/CategoryContext.tsx`](diffhunk://#diff-03e2e3902c0f740380fd927bd061578062a0d0940a924bc55297fd3670570b97R21): Updated the `CategoryContextType` to include a `loading` boolean and passed the `loading` state from the provider. [[1]](diffhunk://#diff-03e2e3902c0f740380fd927bd061578062a0d0940a924bc55297fd3670570b97R21) [[2]](diffhunk://#diff-03e2e3902c0f740380fd927bd061578062a0d0940a924bc55297fd3670570b97R41) [[3]](diffhunk://#diff-03e2e3902c0f740380fd927bd061578062a0d0940a924bc55297fd3670570b97R51)
* [`front/src/features/app/hooks/categories/useCategories.ts`](diffhunk://#diff-5183884ee752098cb1e59d98ff18d06e777af23ca500be84a0edd7b5e4080be7R20): Introduced a `loading` state in the `useCategories` hook and set it to `false` after fetching categories. [[1]](diffhunk://#diff-5183884ee752098cb1e59d98ff18d06e777af23ca500be84a0edd7b5e4080be7R20) [[2]](diffhunk://#diff-5183884ee752098cb1e59d98ff18d06e777af23ca500be84a0edd7b5e4080be7R115) [[3]](diffhunk://#diff-5183884ee752098cb1e59d98ff18d06e777af23ca500be84a0edd7b5e4080be7R124)

